### PR TITLE
843883 - Add customerInfo to ExternalTransaction/Refund request and response

### DIFF
--- a/swaggerpay/payswaggerlatest.json
+++ b/swaggerpay/payswaggerlatest.json
@@ -3964,7 +3964,8 @@
           "customerInfo": {
             "type": "object",
             "$ref": "#/components/schemas/AMCSPayCustomerInfo",
-            "nullable": true
+            "nullable": true,
+            "description": "The customer details associated to the refund request."
           }
         }
       },
@@ -4127,7 +4128,8 @@
           "customerInfo": {
             "type": "object",
             "$ref": "#/components/schemas/AMCSPayCustomerInfo",
-            "nullable": true
+            "nullable": true,
+            "description": "The customer details associated to the refund response."
           }
         },
         "additionalProperties": false

--- a/swaggerpay/payswaggerlatest.json
+++ b/swaggerpay/payswaggerlatest.json
@@ -631,7 +631,7 @@
           "ExternalTransaction"
         ],
         "summary": "Refund Payment",
-        "description": "This endpoint is used to request a refund for a Card/ACH payment already processed via AmcsPay.\n\n## Request\n\n| **Property** | **Description** |\n| --- | --- |\n| RequestType | Request Type is  \"Refund\". |\n| PaymentType | Payment Type can be any of \"CARD\", \"ACH\", \"EFT\", \"TERMINAL\".| \n| TransactionOrigin | For Refund, transaction origin can only be \"MOTO\". |\n| CallerIdentifier | The identification associated to the calling application.| \n| RequestId | The Caller supplied GUID associated to the Payment request.|\n| CallerIPAddress | The IP Address associated to the the customer's location.|\n| ProviderType | Provide Type can be any of \"ACICards\", \"ACIElectronic\", \"Heartland\", \"MerchantPartners\", \"Payment Express\", \"Realex\", \"EftCanada\", \"TerminalPay\", \"ElavonTerminalPay\".| \n| TransactionAmount | The amount subjected for refund.|\n| OriginalPaymentReference | The reference ID sent by the provider associated to the original payment being refunded.|\n| OriginalAmount | The original amount sent by the provider associated to the original payment being refunded. |\n| TokenValue | The Token value associated to the payment. |\n| ProfileExpiryDate | The Profile/Card expiry date sent by the provider associated to the original payment in (MM/YY) format. |\n\n## Response\n\n| **Property** | **Description** |\n| --- | --- |\n| AMCSPayReferenceId | The AMCS generated Response GUID associated to the Payment request. |\n| ProviderReference | The reference number associated to the payment provider response. |\n| ProviderResponseCode | The status code associated to the payment provider response. |\n| ProviderAuthCode | The authorization code associated to the payment provider. |\r\n| TransactionAmount                     |The amount associated to the payment request.        |\r\n| TransactionAmount.PrincipalAmount                     |The base amount associated to the payment request (This field is optional for Tokenization).        |\r\n| TransactionAmount.Currency                     |The currency associated to the payment request.    |\n| ResponseTimeStamp | The time stamp associated to the response payload. |\n| Notes | More information associated to the payment. |\n| TransactionStatus | The Transaction Status associated to the refund response can be any of type \"Initiated\" or \"Failure\".",
+        "description": "This endpoint is used to request a refund for a Card/ACH payment already processed via AmcsPay.\n\n## Request\n\n| **Property** | **Description** |\n| --- | --- |\n| RequestType | Request Type is  \"Refund\". |\n| PaymentType | Payment Type can be any of \"CARD\", \"ACH\", \"EFT\", \"TERMINAL\".| \n| TransactionOrigin | For Refund, transaction origin can only be \"MOTO\". |\n| CallerIdentifier | The identification associated to the calling application.| \n| RequestId | The Caller supplied GUID associated to the Payment request.|\n| CallerIPAddress | The IP Address associated to the the customer's location.|\n| ProviderType | Provide Type can be any of \"ACICards\", \"ACIElectronic\", \"Heartland\", \"MerchantPartners\", \"Payment Express\", \"Realex\", \"EftCanada\", \"TerminalPay\", \"ElavonTerminalPay\".| \n| TransactionAmount | The amount subjected for refund.|\n| OriginalPaymentReference | The reference ID sent by the provider associated to the original payment being refunded.|\n| OriginalAmount | The original amount sent by the provider associated to the original payment being refunded. |\n| TokenValue | The Token value associated to the payment. |\n| ProfileExpiryDate | The Profile/Card expiry date sent by the provider associated to the original payment in (MM/YY) format. |\n| CustomerInfo | The customer details associated to the refund request. |\n\n## Response\n\n| **Property** | **Description** |\n| --- | --- |\n| AMCSPayReferenceId | The AMCS generated Response GUID associated to the Payment request. |\n| ProviderReference | The reference number associated to the payment provider response. |\n| ProviderResponseCode | The status code associated to the payment provider response. |\n| ProviderAuthCode | The authorization code associated to the payment provider. |\r\n| TransactionAmount                     |The amount associated to the payment request.        |\r\n| TransactionAmount.PrincipalAmount                     |The base amount associated to the payment request (This field is optional for Tokenization).        |\r\n| TransactionAmount.Currency                     |The currency associated to the payment request.    |\n| ResponseTimeStamp | The time stamp associated to the response payload. |\n| Notes | More information associated to the payment. |\n| TransactionStatus | The Transaction Status associated to the refund response can be any of type \"Initiated\" or \"Failure\". |\n| CustomerInfo | The customer details associated to the refund response. |",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3964,8 +3964,7 @@
           "customerInfo": {
             "type": "object",
             "$ref": "#/components/schemas/AMCSPayCustomerInfo",
-            "nullable": true,
-            "description": "The customer details associated to the refund request."
+            "nullable": true
           }
         }
       },
@@ -4128,8 +4127,7 @@
           "customerInfo": {
             "type": "object",
             "$ref": "#/components/schemas/AMCSPayCustomerInfo",
-            "nullable": true,
-            "description": "The customer details associated to the refund response."
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/swaggerpay/payswaggerlatest.json
+++ b/swaggerpay/payswaggerlatest.json
@@ -3960,6 +3960,11 @@
             "example": "MM/YY",
             "description": "<span style='color: rgb(212, 31, 28)'>Required if payment type is elavon terminalPay.</span>"
 
+          },
+          "customerInfo": {
+            "type": "object",
+            "$ref": "#/components/schemas/AMCSPayCustomerInfo",
+            "nullable": true
           }
         }
       },
@@ -4118,6 +4123,11 @@
             "$ref": "#/components/schemas/AMCSPayResult",
             "nullable": true,
             "description": "AMCS Pay standardised result code and message returned by the payment provider."
+          },
+          "customerInfo": {
+            "type": "object",
+            "$ref": "#/components/schemas/AMCSPayCustomerInfo",
+            "nullable": true
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
Adds the customerInfo field (referencing the existing AMCSPayCustomerInfo schema) to both the AMCSPayRefundRequest and AMCSPayRefundResponse schemas. The field includes customerName, customerId, customerIP, customerStatus, and websiteUrl. Endpoint description tables updated accordingly.
<img width="1211" height="1008" alt="OVERVIEW" src="https://github.com/user-attachments/assets/ff654254-aeee-43c4-be9a-04a568ec1a34" />
<img width="675" height="985" alt="DETAILS" src="https://github.com/user-attachments/assets/ca9e2874-e120-4039-95a6-e379ec5776a7" />


For: https://dev.azure.com/amcsgroup/Platform/_workitems/edit/843883