### PR TITLE
Update Swagger/OpenAPI spec for Stripe Card payments (Track 1) to unblock ERP integration

### DIFF
--- a/swaggerpay/payswaggerlatest.json
+++ b/swaggerpay/payswaggerlatest.json
@@ -342,7 +342,7 @@
           "ExternalTransaction"
         ],
         "summary": "OneOff Payment",
-        "description": "This endpoint is used to initiate a payment/tokenization request via the Provider's hosted payments page (HPP).\n\n## Request\n\n| Property                  | Description  |\r\n| ------------------------- | ------------------------------------------------------------------------|\r\n| RequestType                      |Request Type can be any of \"OneOffPayment\", \"Tokenization\".                            |\r\n| PaymentType               | Payment Type can be any of \"CARD\", \"ACH\", \"EFT\".                      |\r\n| TransactionOrigin                 | Transaction Origin can be any of \"MOTO\", \"ECOM\"        |\r\n| CallerIdentifier               | The Caller Identification associated to the Payment request.             |\r\n| RequestId               | The Caller supplied GUID associated to the Payment request.        |\r\n| ProviderType                   |Provide Type can be any of \"ACICards\", \"ACIElectronic\", \"Heartland\", \"MerchantPartners\",  \"Payment Express\", \"Realex\"        |\r\n| ConfigurationId                      |The configuration id associated to the Tenant.                            |\r\n| TransactionAmount                     |The amount associated to the payment request.        |\r\n| TransactionAmount.PrincipalAmount                     |The base amount associated to the payment request (This field is optional for Tokenization).        |\r\n| TransactionAmount.Currency                     |The currency associated to the payment request.        |\r\n| CanStoreProfile                         | The flag suggests store the profile to vault.        |\r\n| CompletionURL                         | The Completion URL Request associated to the customer mandate for webhooks.        |\r\n| RedirectURL                         | The Redirect URL associated to the customer mandate for redirection.        |\r\n| Addresses                         | The List of addresses associated to the customer mandate for 3ds transaction (Billing address is mandatory for 3ds enabled transaction).        |\r\n| Addresses[0].AddressType                         | The AddressType associated to the address can be any of \"Billing\", \"Shipping\".        |\r\n| Addresses[0].StreetAddress1                         | The StreetAddress Line1 associated to the address.        |\r\n| Addresses[0].StreetAddress2                         | The StreetAddress Line2 associated to the address.        |\r\n| Addresses[0].StreetAddress3                         | The StreetAddress Line3 associated to the address (Conditionally required).        |\r\n| Addresses[0].City                         | The City associated to the address.        |\r\n| Addresses[0].State                         | The State associated to the address.        |\r\n| Addresses[0].PostCode                         | The PostCode associated to the address.        |\r\n| Addresses[0].Country                         | The Country associated to the address.        |\r\n| Addresses[0].ISO3166Numeric                         | The ISO3166Numeric associated to the address (Conditionally required).        |\r\n| Contacts                         | The Contacts associated to the customer mandate for 3ds transaction (Contact type 'Mobile' and 'Email' are mandatory for 3ds enabled transaction).        |\r\n| Contacts[0].ContactType                         | The Contact Type associated to the contact can be any of type \"Email\", \"Mobile\".        |\r\n| Contacts[0].ContactValue                         | The Contact Value associated to the contact type.        |\r\n| CustomerInfo                         | The Details associated to the customer mandate for risk assessment (Conditionally required for making payments using ACI Cards).        |\r\n| CustomerInfo.CustomerName                         | The Customer Name associated to the customer.        |\r\n| CustomerInfo.CustomerId                         | The Customer Id associated to the customer.        |\r\n| CustomerInfo.CustomerIP                         | The Customer Ip associated to the customer.        |\r\n| CustomerInfo.CustomerStatus                         | The Customer Status associated to the customer.        |\r\n| CustomerInfo.WebsiteUrl                         | The Website Url associated to the customer.\n\n## Response\n\n| Property                  | Description  |\r\n| ------------------------- | ------------------------------------------------------------------------|\r\n| HppUrl                      | The Hosted Payment Page Url to load in a frame/browser.        |\r\n| CallerTransactionId               |  The AMCS generated Request GUID associated to the Payment request.                              |\r\n| TransactionAmount                     |The amount associated to the payment request.        |\r\n| TransactionAmount.PrincipalAmount                     |The base amount associated to the payment request (This field is optional for Tokenization).        |\r\n| TransactionAmount.Currency                     |The currency associated to the payment request.                              |\r\n| TransactionStatus                 | The Transaction Status associated to the Payment request.",
+        "description": "This endpoint is used to initiate a payment/tokenization request via the Provider's hosted payments page (HPP). See the request/response schema below for field-level guidance, including which values `providerType` and `transactionOrigin` accept and when to use each.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -448,7 +448,7 @@
           "ExternalTransaction"
         ],
         "summary": "Poll Payment",
-        "description": "This endpoint is used to poll AmcsPay to ask for query transactions or to read the transaction response back to AmcsPay from the payment provider using CallerTransactionId or RequestId.\n\n## Request\n\n| **Property** | **Description** |\n| --- | --- |\n| CallerTransactionId | The AMCS generated Request GUID associated to the payments. |\n| RequestId | The Caller Supplied Request GUID associated to the payments. |\n\n## Response\n\n| **Property** | **Description** |\n| --- | --- |\n| CallerTransactionId | The AMCS generated Request GUID associated to the payments. |\n| AMCSPayReferenceId | The AMCS generated Response GUID associated to the Payment request. |\n| ProviderReference | The reference number associated to the payment provider. |\n| ProviderResponseCode | The response code associated to the payment provider. |\n| Notes | More information associated to the payment. |\n| ProviderAuthCode | The authorization code associated to the payment provider.  |\n| ResponseTimeStamp | The Timestamp of the payment response payload. |\n| TransactionStatus | The Transaction Status associated to the payment can be any of type \"Initiated\", \"Success\", \"Failure\", \"Timeout\", \"Cancelled\". |\n| TokenReference | The Token Reference sent by the provider associated to the original payment (Tokenisation Response). |\n| HistoryReference | The history reference data sent by the provider associated to the original payment (Tokenisation Response). |\n| MaskedProfileNumber | The Profile/Card Number sent by the provider associated to the original payment (Tokenisation Response) (Conditionally required). |\n| ProfileType | The Profile/Card Type sent by the provider associated to the original payment (Tokenisation Response). |\n| ProfileHolder | The Profile/Card Holder Name sent by the provider associated to the original payment (Tokenisation Response). |\n| ProfileExpiryDate | The Profile/Card expiry date sent by the  provider associated to the original payment in (MM/YY) format. |\r\n| TransactionAmount                     |The amount associated to the payment request.        |\r\n| TransactionAmount.PrincipalAmount                     |The base amount associated to the payment request (This field is optional for Tokenization).        |\r\n| TransactionAmount.Currency                     |The currency associated to the payment request.        |\r\n| ErrorCondition                     |The error condition associated to the payment request.",
+        "description": "This endpoint is used to poll AmcsPay to ask for query transactions or to read the transaction response back to AmcsPay from the payment provider using CallerTransactionId or RequestId. See the response schema below for field-level guidance, including all `transactionStatus` values. Note: this endpoint is used by non-ERP external applications — ERP payment completion is instead delivered via a separate Platform postback endpoint.",
         "parameters": [
           {
             "name": "callerTransactionId",
@@ -631,7 +631,7 @@
           "ExternalTransaction"
         ],
         "summary": "Refund Payment",
-        "description": "This endpoint is used to request a refund for a Card/ACH payment already processed via AmcsPay.\n\n## Request\n\n| **Property** | **Description** |\n| --- | --- |\n| RequestType | Request Type is  \"Refund\". |\n| PaymentType | Payment Type can be any of \"CARD\", \"ACH\", \"EFT\", \"TERMINAL\".| \n| TransactionOrigin | For Refund, transaction origin can only be \"MOTO\". |\n| CallerIdentifier | The identification associated to the calling application.| \n| RequestId | The Caller supplied GUID associated to the Payment request.|\n| CallerIPAddress | The IP Address associated to the the customer's location.|\n| ProviderType | Provide Type can be any of \"ACICards\", \"ACIElectronic\", \"Heartland\", \"MerchantPartners\", \"Payment Express\", \"Realex\", \"EftCanada\", \"TerminalPay\", \"ElavonTerminalPay\".| \n| TransactionAmount | The amount subjected for refund.|\n| OriginalPaymentReference | The reference ID sent by the provider associated to the original payment being refunded.|\n| OriginalAmount | The original amount sent by the provider associated to the original payment being refunded. |\n| TokenValue | The Token value associated to the payment. |\n| ProfileExpiryDate | The Profile/Card expiry date sent by the provider associated to the original payment in (MM/YY) format. |\n| CustomerInfo | The customer details associated to the refund request. |\n\n## Response\n\n| **Property** | **Description** |\n| --- | --- |\n| AMCSPayReferenceId | The AMCS generated Response GUID associated to the Payment request. |\n| ProviderReference | The reference number associated to the payment provider response. |\n| ProviderResponseCode | The status code associated to the payment provider response. |\n| ProviderAuthCode | The authorization code associated to the payment provider. |\r\n| TransactionAmount                     |The amount associated to the payment request.        |\r\n| TransactionAmount.PrincipalAmount                     |The base amount associated to the payment request (This field is optional for Tokenization).        |\r\n| TransactionAmount.Currency                     |The currency associated to the payment request.    |\n| ResponseTimeStamp | The time stamp associated to the response payload. |\n| Notes | More information associated to the payment. |\n| TransactionStatus | The Transaction Status associated to the refund response can be any of type \"Initiated\" or \"Failure\". |\n| CustomerInfo | The customer details associated to the refund response. |",
+        "description": "This endpoint is used to request a refund for a Card/ACH payment already processed via AmcsPay, including payments made via Stripe. See the request/response schema below for field-level guidance, including which values `providerType` and `transactionOrigin` accept and when to use each.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -853,7 +853,7 @@
           "ExternalTransaction"
         ],
         "summary": "Delete Token",
-        "description": "This endpoint is used to delete Card Tokens from the vault for both AMCS Pay and Payment provider gateway.",
+        "description": "This endpoint is used to delete Card Tokens from the vault for both AMCS Pay and Payment provider gateway. See the request schema below for field-level guidance, including which values `providerType` and `transactionOrigin` accept and when to use each.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -916,6 +916,124 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AMCSPayErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ExternalTransaction/TokenVault": {
+      "get": {
+        "tags": [
+          "ExternalTransaction"
+        ],
+        "summary": "Get Token Vault",
+        "description": "This endpoint is used to retrieve the active saved payment profiles (tokens) stored for a customer.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The customerId associated to the customer. Required — a 400 Bad Request is returned if omitted or blank."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AMCSPayTokenVaultResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AMCSPayErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AMCSPayErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ExternalTransaction/SetDefault": {
+      "post": {
+        "tags": [
+          "ExternalTransaction"
+        ],
+        "summary": "Set Default Token",
+        "description": "This endpoint is used to mark a customer's saved payment profile (token) as their default for future Vault payments.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AMCSPaySetDefaultRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true,
+                      "description": "Indicates the default payment profile was updated successfully."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AMCSPayErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
           },
           "500": {
             "description": "Internal Server Error",
@@ -1810,7 +1928,8 @@
               "OneOffPayment",
               "Tokenization"
             ],
-            "nullable": false
+            "nullable": false,
+            "description": "Determines what kind of operation this request performs.\n\n- **OneOffPayment** — Process a single payment via the provider's hosted payment page (HPP), without saving payment details for future reuse.\n- **Tokenization** — Capture and store payment details via the HPP for future Vault payments, without processing a payment now."
           },
           "paymentType": {
             "type": "string",
@@ -1819,7 +1938,8 @@
               "ACH",
               "EFT"
             ],
-            "nullable": false
+            "nullable": false,
+            "description": "The payment instrument type for this request.\n\n- **CARD** — Card payment (credit/debit).\n- **ACH** — US bank account transfer (Automated Clearing House).\n- **EFT** — Canadian bank account transfer (Electronic Funds Transfer)."
           },
           "transactionOrigin": {
             "type": "string",
@@ -1827,17 +1947,20 @@
               "MOTO",
               "ECOM"
             ],
-            "nullable": false
+            "nullable": false,
+            "description": "Determines whether the payment was operator-initiated or customer-initiated — this affects card scheme compliance classification.\n\n- **MOTO** — Mail Order / Telephone Order. Use when an AMCS operator keys in the payment on the customer's behalf (e.g. a phone payment). This is a Merchant-Initiated Transaction (MIT).\n- **ECOM** — E-commerce. Use when the customer enters their own payment details through a self-service channel (e.g. an online portal). This is a Customer-Initiated Transaction (CIT).\n\nUsing the wrong value can misclassify liability under card network compliance rules. Required for Stripe — the APG/EFT Canada exemption from this requirement does not apply to Stripe."
           },
           "callerIdentifier": {
             "type": "string",
-            "nullable": false
+            "nullable": false,
+            "description": "The Caller Identification associated to the Payment request."
           },
           "requestId": {
             "type": "string",
             "format": "uuid",
             "example": "00000000-0000-0000-0000-000000000000",
-            "nullable": false
+            "nullable": false,
+            "description": "The Caller supplied GUID associated to the Payment request."
           },
           "providerType": {
             "type": "string",
@@ -1848,56 +1971,66 @@
               "MerchantPartners",
               "PaymentExpress",
               "Realex",
-              "EftCanada"
+              "EftCanada",
+              "Stripe"
             ],
-            "nullable": false
+            "nullable": false,
+            "description": "The payment provider used to process this request.\n\n- **ACICards** — ACI Worldwide card processing.\n- **ACIElectronic** — ACI Worldwide ACH/electronic processing.\n- **Heartland** — Heartland Payment Systems.\n- **MerchantPartners** — Merchant Partners.\n- **PaymentExpress** — Payment Express (Windcave).\n- **Realex** — Realex/Global Payments.\n- **EftCanada** — EFT Canada bank transfers.\n- **Stripe** — Stripe card processing. `transactionOrigin` is required when using Stripe — the APG/EFT Canada exemption from that requirement does not apply."
           },
           "configurationId": {
             "type": "string",
             "format": "uuid",
             "example": "928a3c6c-b80d-493d-a6aa-0fb8d2579860",
-            "nullable": true
+            "nullable": true,
+            "description": "The configuration id associated to the Tenant. Optional — only used when the tenant's provider-configuration migration feature is enabled; if omitted (or the feature is disabled), the request is resolved using `providerType` alone."
           },
           "transactionAmount": {
             "type": "object",
             "$ref": "#/components/schemas/AMCSPayAmount",
-            "nullable": false
+            "nullable": false,
+            "description": "The amount associated to the payment request."
           },
           "canStoreProfile": {
             "type": "boolean",
             "example": false,
-            "nullable": true
+            "nullable": true,
+            "description": "Whether to store the payment profile to the vault for future Vault payments. Optional — defaults to false (profile is not stored) if omitted."
           },
           "completionURL": {
             "type": "string",
             "format": "url",
             "example": "",
-            "nullable": true
+            "nullable": true,
+            "description": "The Completion URL associated to the customer mandate for webhooks. Optional."
           },
           "redirectURL": {
             "type": "string",
             "format": "url",
             "example": "",
-            "nullable": true
+            "nullable": true,
+            "description": "The Redirect URL associated to the customer mandate for redirection. Optional."
           },
           "addresses": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/AMCSPayAddress"
             },
-            "nullable": true
+            "nullable": true,
+            "description": "The list of addresses associated to the customer mandate for 3DS transactions. Optional unless 3DS is enabled, in which case a Billing address is mandatory."
           },
           "contacts": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/AMCSPayContact"
             },
-            "nullable": true
+            "nullable": true,
+            "description": "The contacts associated to the customer mandate for 3DS transactions. Optional unless 3DS is enabled, in which case Email and Mobile contact types are both mandatory."
           },
           "customerInfo": {
             "type": "object",
             "$ref": "#/components/schemas/AMCSPayCustomerInfo",
-            "nullable": true
+            "nullable": true,
+            "description": "The details associated to the customer mandate for risk assessment. Conditionally required for making payments using ACI Cards; optional otherwise."
           }
         }
       },
@@ -2630,24 +2763,28 @@
           "hppUrl": {
             "format": "url",
             "type": "string",
-            "example": "https://localhost/paybylink?key=092159d8-9e57-41a5-af6c-745bd45ff2f7"
+            "example": "https://localhost/paybylink?key=092159d8-9e57-41a5-af6c-745bd45ff2f7",
+            "description": "The Hosted Payment Page Url to load in a frame/browser."
           },
           "callerTransactionId": {
             "format": "uuid",
             "example": "00000000-0000-0000-0000-000000000000",
-            "type": "string"
+            "type": "string",
+            "description": "The AMCS generated Request GUID associated to the Payment request."
           },
           "transactionAmount": {
             "type": "object",
             "$ref": "#/components/schemas/AMCSPayAmount",
-            "nullable": false
+            "nullable": false,
+            "description": "The amount associated to the payment request."
           },
           "transactionStatus": {
             "type": "string",
             "enum": [
               "Initiated"
             ],
-            "example": "Initiated"
+            "example": "Initiated",
+            "description": "The Transaction Status associated to the Payment request. Always \"Initiated\" for this endpoint — poll for the final outcome using GET /ExternalTransaction/Poll with the returned `callerTransactionId`."
           }
         }
       },
@@ -3112,12 +3249,14 @@
               "Mobile"
             ],
             "example": "Email",
-            "nullable": false
+            "nullable": false,
+            "description": "The Contact Type associated to the contact.\n\n- **Email** — An email address.\n- **Mobile** — A mobile phone number."
           },
           "contactValue": {
             "type": "string",
             "example": "089748588788",
-            "nullable": false
+            "nullable": false,
+            "description": "The Contact Value associated to the contact type."
           }
         }
       },
@@ -3127,17 +3266,20 @@
           "customerName": {
             "type": "string",
             "example": "",
-            "nullable": true
+            "nullable": true,
+            "description": "The Customer Name associated to the customer."
           },
           "customerId": {
             "type": "string",
             "example": "ACC1007",
-            "nullable": false
+            "nullable": false,
+            "description": "The Customer Id associated to the customer."
           },
           "customerIP": {
             "type": "string",
             "example": "000.000.0.000",
-            "nullable": true
+            "nullable": true,
+            "description": "The Customer Ip associated to the customer."
           },
           "customerStatus": {
             "type": "string",
@@ -3146,12 +3288,14 @@
               "EXISTING"
             ],
             "example": "NEW",
-            "nullable": false
+            "nullable": false,
+            "description": "The Customer Status associated to the customer.\n\n- **NEW** — The customer has no stored payment profile yet.\n- **EXISTING** — The customer is a returning customer with a previously stored payment profile."
           },
           "websiteUrl": {
             "type": "string",
             "example": "",
-            "nullable": true
+            "nullable": true,
+            "description": "The Website Url associated to the customer."
           }
         },
         "additionalProperties": false
@@ -3353,47 +3497,56 @@
               "Shipping"
             ],
             "example": "Billing",
-            "nullable": false
+            "nullable": false,
+            "description": "The address type.\n\n- **Billing** — The billing address. Mandatory for 3DS-enabled transactions.\n- **Shipping** — The shipping address."
           },
           "streetAddress1": {
             "type": "string",
             "example": "27, Longwood Avenue",
-            "nullable": false
+            "nullable": false,
+            "description": "Street address line 1."
           },
           "streetAddress2": {
             "type": "string",
             "example": "South Circular",
-            "nullable": false
+            "nullable": false,
+            "description": "Street address line 2."
           },
           "streetAddress3": {
             "type": "string",
             "example": "Road Dublin-08",
-            "nullable": true
+            "nullable": true,
+            "description": "Street address line 3. Conditionally required."
           },
           "city": {
             "type": "string",
             "example": "Dublin",
-            "nullable": false
+            "nullable": false,
+            "description": "The city associated to the address."
           },
           "state": {
             "type": "string",
             "example": "Munster",
-            "nullable": false
+            "nullable": false,
+            "description": "The state/region associated to the address."
           },
           "postCode": {
             "type": "string",
             "example": "12345",
-            "nullable": false
+            "nullable": false,
+            "description": "The postal/zip code associated to the address."
           },
           "country": {
             "type": "string",
             "example": "Ireland",
-            "nullable": false
+            "nullable": false,
+            "description": "The country associated to the address."
           },
           "iSO3166Numeric": {
             "type": "string",
             "example": "372",
-            "nullable": false
+            "nullable": false,
+            "description": "The ISO 3166-1 numeric country code associated to the address. Conditionally required."
           }
         }
       },
@@ -3403,85 +3556,105 @@
           "callerTransactionId": {
             "type": "string",
             "nullable": true,
-            "example": "d0c645e2-4e7b-4dd8-b304-b02600e6179a"
+            "example": "d0c645e2-4e7b-4dd8-b304-b02600e6179a",
+            "description": "The AMCS generated Request GUID associated to the payments."
           },
           "amcsPayReferenceId": {
             "type": "string",
             "nullable": true,
-            "example": "f9a50643-05e3-45f9-9bc0-87be0d5ae0e2"
+            "example": "f9a50643-05e3-45f9-9bc0-87be0d5ae0e2",
+            "description": "The AMCS generated Response GUID associated to the Payment request."
           },
           "providerReference": {
             "type": "string",
             "nullable": true,
-            "example": "8ac7a4a28749242d01874c7e648327b7"
+            "example": "8ac7a4a28749242d01874c7e648327b7",
+            "description": "The reference number associated to the payment provider."
           },
           "providerResponseCode": {
             "type": "string",
             "nullable": true,
-            "example": "OK"
+            "example": "OK",
+            "description": "The response code associated to the payment provider."
           },
           "providerAuthCode": {
             "type": "string",
             "nullable": true,
-            "example": ""
+            "example": "",
+            "description": "The authorization code associated to the payment provider."
           },
           "transactionAmount": {
             "type": "object",
             "$ref": "#/components/schemas/AMCSPayAmount",
-            "nullable": true
+            "nullable": true,
+            "description": "The amount associated to the payment request."
           },
           "responseTimeStamp": {
             "type": "string",
             "format": "datetime",
             "nullable": true,
-            "example": "2022-07-27 18:54:18.6767965 +08:00"
+            "example": "2022-07-27 18:54:18.6767965 +08:00",
+            "description": "The Timestamp of the payment response payload."
           },
           "notes": {
             "type": "string",
             "nullable": true,
-            "example": ""
+            "example": "",
+            "description": "More information associated to the payment."
           },
           "transactionStatus": {
             "type": "string",
             "enum": [
               "Initiated",
-              "Exception",
               "Success",
-              "Failure"
+              "Failure",
+              "Timeout",
+              "Cancelled",
+              "InvalidCardInformation",
+              "Exception",
+              "Partial",
+              "Processing"
             ],
             "example": "Success",
-            "nullable": false
+            "nullable": false,
+            "description": "The Transaction Status associated to the payment.\n\n- **Initiated** — The request has been accepted and is awaiting a result from the provider.\n- **Success** — The payment completed successfully.\n- **Failure** — The payment did not complete; check `notes`/`result` for details.\n- **Timeout** — No response was received from the provider/device within the expected time.\n- **Cancelled** — The payment was cancelled before completion.\n- **InvalidCardInformation** — The payment failed due to invalid card details.\n- **Exception** — An unexpected error occurred while processing the payment.\n- **Partial** — The provider/device response was incomplete; check the device or poll again to confirm the outcome.\n- **Processing** — The payment is still being processed by the provider."
           },
           "tokenReference": {
             "type": "string",
             "nullable": true,
-            "example": "58af616d8b112af873be57bb627a7677bdffdc6a306ffdff26c6f6b59d917fe7"
+            "example": "58af616d8b112af873be57bb627a7677bdffdc6a306ffdff26c6f6b59d917fe7",
+            "description": "The Token Reference sent by the provider associated to the original payment (Tokenisation Response)."
           },
           "historyReference": {
             "type": "string",
             "nullable": true,
-            "example": "123456789012345"
+            "example": "123456789012345",
+            "description": "The history reference data sent by the provider associated to the original payment (Tokenisation Response)."
           },
           "maskedProfileNumber": {
             "type": "string",
             "nullable": true,
-            "example": "XXXXX"
+            "example": "XXXXX",
+            "description": "The Profile/Card Number sent by the provider associated to the original payment (Tokenisation Response) (Conditionally required)."
           },
           "profileExpiryDate": {
             "type": "string",
             "nullable": true,
             "format": "datetime",
-            "example": "MM/YY"
+            "example": "MM/YY",
+            "description": "The Profile/Card expiry date sent by the provider associated to the original payment, in (MM/YY) format."
           },
           "profileType": {
             "type": "string",
             "nullable": true,
-            "example": "VISA"
+            "example": "VISA",
+            "description": "The Profile/Card Type sent by the provider associated to the original payment (Tokenisation Response)."
           },
           "profileHolder": {
             "type": "string",
             "nullable": true,
-            "example": "Roofus Summers"
+            "example": "Roofus Summers",
+            "description": "The Profile/Card Holder Name sent by the provider associated to the original payment (Tokenisation Response)."
           },
           "errorCondition": {
             "type": "string",
@@ -3505,7 +3678,8 @@
               "WRONGPIN"
             ],
             "example": "CANCEL",
-            "nullable": true
+            "nullable": true,
+            "description": "The error condition returned by the payment provider or terminal device when a transaction does not complete; only present for terminal-based payment errors."
           },
           "result": {
             "$ref": "#/components/schemas/AMCSPayResult",
@@ -3615,7 +3789,7 @@
             "type": "string",
             "nullable": true,
             "example": "MOTO",
-            "description": "The payment transaction payment type."
+            "description": "Whether the payment was operator-initiated or customer-initiated.\n\n- **MOTO** — Mail Order / Telephone Order (Merchant-Initiated Transaction).\n- **ECOM** — E-commerce (Customer-Initiated Transaction)."
           },
           "callerIdentifier": {
             "type": "string",
@@ -3818,14 +3992,15 @@
               "APPLEPAY"
             ],
             "type": "string",
-            "description": "The supported payment type for this endpoint is \"CARD\"."
+            "description": "The payment instrument type of the saved profile being deleted.\n\n- **CARD** — Card payment (credit/debit).\n- **ACH** — US bank account transfer (Automated Clearing House).\n- **GOOGLEPAY** — Google Pay wallet.\n- **APPLEPAY** — Apple Pay wallet."
           },
           "transactionOrigin": {
             "enum": [
               "MOTO",
               "ECOM"
             ],
-            "type": "string"
+            "type": "string",
+            "description": "Determines whether the request was operator-initiated or customer-initiated — this affects card scheme compliance classification.\n\n- **MOTO** — Mail Order / Telephone Order. Use when an AMCS operator initiates this on the customer's behalf. This is a Merchant-Initiated Transaction (MIT).\n- **ECOM** — E-commerce. Use when the customer initiates this themselves through a self-service channel. This is a Customer-Initiated Transaction (CIT).\n\nUsing the wrong value can misclassify liability under card network compliance rules. Required for Stripe — the APG/EFT Canada exemption from this requirement does not apply to Stripe."
           },
           "callerIdentifier": {
             "minLength": 1,
@@ -3858,11 +4033,12 @@
               "AptPay",
               "PaymentExpress",
               "EftCanada",
-              "TerminalPay"
+              "TerminalPay",
+              "Stripe"
             ],
             "type": "string",
             "example": "ACICards",
-            "description": "The payment providers integrated to AMCS Pay. This endpoint only supports \"ACICards\"."
+            "description": "The payment provider that holds the saved payment profile being deleted.\n\n- **ACICards** — ACI Worldwide card processing.\n- **ACIElectronic** — ACI Worldwide ACH/electronic processing.\n- **Heartland** — Heartland Payment Systems.\n- **MerchantPartners** — Merchant Partners.\n- **PaymentExpress** — Payment Express (Windcave).\n- **Realex** — Realex/Global Payments.\n- **EftCanada** — EFT Canada bank transfers.\n- **AptPay** — AptPay.\n- **TerminalPay** — Verifone terminal device payments.\n- **Test** — Internal test provider.\n- **Stripe** — Stripe card processing. `transactionOrigin` is required when using Stripe — the APG/EFT Canada exemption from that requirement does not apply."
           },
           "referenceId": {
             "type": "string",
@@ -3931,6 +4107,92 @@
         },
         "additionalProperties": false
       },
+      "AMCSPayTokenVaultResponse": {
+        "type": "object",
+        "properties": {
+          "payTokenReference": {
+            "type": "string",
+            "format": "uuid",
+            "example": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "nullable": true,
+            "description": "The AMCS Pay generated reference for this saved payment profile (token)."
+          },
+          "providerTokenReference": {
+            "type": "string",
+            "nullable": true,
+            "description": "The token reference sent by the payment provider for this saved payment profile."
+          },
+          "accountHolder": {
+            "type": "string",
+            "nullable": true,
+            "description": "The name of the account/card holder associated with this saved payment profile."
+          },
+          "maskedAccountNumber": {
+            "type": "string",
+            "nullable": true,
+            "description": "The masked card/account number associated with this saved payment profile."
+          },
+          "expiryDate": {
+            "type": "string",
+            "format": "dateTimeOffset",
+            "example": "2000-01-01T00:00:00.0000000+01:00",
+            "nullable": true,
+            "description": "The expiry date of the saved payment profile, where applicable (e.g. card expiry)."
+          },
+          "isDirectDebit": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether this saved payment profile is a direct debit mandate rather than a card/ACH profile."
+          },
+          "paymentTypeId": {
+            "type": "integer",
+            "example": 0,
+            "nullable": true,
+            "description": "The internal identifier of the payment type for this saved payment profile."
+          },
+          "paymentTypeName": {
+            "type": "string",
+            "nullable": true,
+            "description": "The name of the payment type for this saved payment profile (e.g. \"CARD\")."
+          },
+          "paymentProviderId": {
+            "type": "integer",
+            "example": 0,
+            "nullable": true,
+            "description": "The internal identifier of the payment provider that holds this saved payment profile."
+          },
+          "paymentProviderName": {
+            "type": "string",
+            "nullable": true,
+            "description": "The name of the payment provider that holds this saved payment profile (e.g. \"Stripe\")."
+          },
+          "profileType": {
+            "type": "string",
+            "nullable": true,
+            "description": "The card/profile brand or type associated with this saved payment profile (e.g. \"VISA\")."
+          },
+          "isDefault": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether this is the customer's default saved payment profile for future Vault payments."
+          }
+        }
+      },
+      "AMCSPaySetDefaultRequest": {
+        "type": "object",
+        "properties": {
+          "customerId": {
+            "type": "string",
+            "nullable": true,
+            "description": "The customerId associated to the customer whose default payment profile is being changed."
+          },
+          "providerTokenReference": {
+            "type": "string",
+            "nullable": true,
+            "description": "The provider token reference (as returned by GET /ExternalTransaction/TokenVault) of the saved payment profile to set as default."
+          }
+        }
+      },
       "AMCSPayRefundRequest": {
         "required": [
           "requestType",
@@ -3951,7 +4213,8 @@
               "Refund"
             ],
             "example": "Refund",
-            "nullable": false
+            "nullable": false,
+            "description": "Request type for this endpoint. Always \"Refund\"."
           },
           "paymentType": {
             "type": "string",
@@ -3962,112 +4225,8 @@
               "TERMINAL"
             ],
             "example": "CARD",
-            "nullable": false
-          },
-          "transactionOrigin": {
-            "type": "string",
-            "enum": [
-              "MOTO"
-            ],
-            "example": "MOTO",
-            "nullable": false
-          },
-          "callerIdentifier": {
-            "type": "string",
-            "example": "Elemos",
-            "nullable": false
-          },
-          "requestId": {
-            "type": "string",
-            "format": "uuid",
-            "example": "00000000-0000-0000-0000-000000000000",
-            "nullable": false
-          },
-          "providerType": {
-            "type": "string",
-            "enum": [
-              "ACICards",
-              "ACIElectronic",
-              "Heartland",
-              "MerchantPartners",
-              "PaymentExpress",
-              "Realex",
-              "TerminalPay",
-              "EftCanada",
-              "ElavonTerminalPay"
-            ],
-            "example": "ACICards",
-            "nullable": false
-          },
-          "transactionAmount": {
-            "type": "object",
-            "example": "24.00",
-            "$ref": "#/components/schemas/AMCSPayAmount",
-            "nullable": false
-          },
-          "originalPaymentReference": {
-            "type": "string",
-            "example": "8ac7a4a28749242d01874c7e648327b7",
-            "nullable": false
-          },
-          "originalAmount": {
-            "type": "number",
-            "format": "decimal",
-            "example": 40.10,
-            "nullable": true
-          },
-          "tokenValue": {
-            "type": "string",
-            "nullable": true,
-            "example": "iLGOd76VSiaAQBcZswQf",
-            "description": "<span style='color: rgb(212, 31, 28)'>Required if payment type is elavon terminalPay or verifone terminalPay.</span>"
-          },
-          "profileExpiryDate": {
-            "type": "string",
-            "nullable": true,
-            "format": "datetime",
-            "example": "MM/YY",
-            "description": "<span style='color: rgb(212, 31, 28)'>Required if payment type is elavon terminalPay.</span>"
-
-          },
-          "customerInfo": {
-            "type": "object",
-            "$ref": "#/components/schemas/AMCSPayCustomerInfo",
-            "nullable": true
-          }
-        }
-      },
-      "AMCSPayVaultRequest": {
-        "required": [
-          "requestType",
-          "paymentType",
-          "transactionOrigin",
-          "callerIdentifier",
-          "requestId",
-          "providerType",
-          "tokenReference"
-        ],
-        "type": "object",
-        "properties": {
-          "requestType": {
-            "type": "string",
-            "enum": [
-              "VaultOrAutoPayment"
-            ],
-            "example": "VaultOrAutoPayment",
             "nullable": false,
-            "description": "Request Type is \"VaultOrAutoPayment\"."
-          },
-          "paymentType": {
-            "type": "string",
-            "enum": [
-              "CARD",
-              "ACH",
-              "EFT"
-            ],
-            "example": "CARD",
-            "nullable": false,
-            "description": "Payment Type can be any of \"CARD\", \"ACH\", \"EFT\"."
+            "description": "The payment instrument type of the original payment being refunded.\n\n- **CARD** — Card payment (credit/debit).\n- **ACH** — US bank account transfer (Automated Clearing House).\n- **EFT** — Canadian bank account transfer (Electronic Funds Transfer).\n- **TERMINAL** — A card-present payment taken on a physical terminal device."
           },
           "transactionOrigin": {
             "type": "string",
@@ -4077,7 +4236,7 @@
             ],
             "example": "MOTO",
             "nullable": false,
-            "description": "Transaction Origin can be any of \"MOTO\", \"ECOM\"."
+            "description": "Determines whether the original payment was operator-initiated or customer-initiated — this affects card scheme compliance classification.\n\n- **MOTO** — Mail Order / Telephone Order. Use when an AMCS operator keys in the payment on the customer's behalf (e.g. a phone payment). This is a Merchant-Initiated Transaction (MIT).\n- **ECOM** — E-commerce. Use when the customer enters their own payment details through a self-service channel (e.g. an online portal). This is a Customer-Initiated Transaction (CIT).\n\nUsing the wrong value can misclassify liability under card network compliance rules. Required for Stripe — the APG/EFT Canada exemption from this requirement does not apply to Stripe."
           },
           "callerIdentifier": {
             "type": "string",
@@ -4101,11 +4260,126 @@
               "MerchantPartners",
               "PaymentExpress",
               "Realex",
-              "EftCanada"
+              "TerminalPay",
+              "EftCanada",
+              "ElavonTerminalPay",
+              "Stripe"
             ],
             "example": "ACICards",
             "nullable": false,
-            "description": "Provide Type can be any of \"ACICards\", \"ACIElectronic\", \"Heartland\", \"MerchantPartners\", \"Payment Express\", \"Realex\", \"EftCanada\"."
+            "description": "The payment provider that processed the original payment. Stripe card refunds are fully supported through this endpoint.\n\n- **ACICards** — ACI Worldwide card processing.\n- **ACIElectronic** — ACI Worldwide ACH/electronic processing.\n- **Heartland** — Heartland Payment Systems.\n- **MerchantPartners** — Merchant Partners.\n- **PaymentExpress** — Payment Express (Windcave).\n- **Realex** — Realex/Global Payments.\n- **EftCanada** — EFT Canada bank transfers.\n- **TerminalPay** — Verifone terminal device payments.\n- **ElavonTerminalPay** — Elavon terminal device payments.\n- **Stripe** — Stripe card processing. `transactionOrigin` is required when using Stripe — the APG/EFT Canada exemption from that requirement does not apply."
+          },
+          "transactionAmount": {
+            "type": "object",
+            "example": "24.00",
+            "$ref": "#/components/schemas/AMCSPayAmount",
+            "nullable": false,
+            "description": "The amount subjected for refund."
+          },
+          "originalPaymentReference": {
+            "type": "string",
+            "example": "8ac7a4a28749242d01874c7e648327b7",
+            "nullable": false,
+            "description": "The reference ID sent by the provider associated to the original payment being refunded. Required."
+          },
+          "originalAmount": {
+            "type": "number",
+            "format": "decimal",
+            "example": 40.10,
+            "nullable": true,
+            "description": "The original amount sent by the provider associated to the original payment being refunded. Required."
+          },
+          "tokenValue": {
+            "type": "string",
+            "nullable": true,
+            "example": "iLGOd76VSiaAQBcZswQf",
+            "description": "The token value associated to the payment. Required if paymentType is TERMINAL and the provider is Elavon TerminalPay or Verifone TerminalPay; optional otherwise."
+          },
+          "profileExpiryDate": {
+            "type": "string",
+            "nullable": true,
+            "format": "datetime",
+            "example": "MM/YY",
+            "description": "The Profile/Card expiry date associated to the original payment, in (MM/YY) format. Required if paymentType is TERMINAL and the provider is Elavon TerminalPay; optional otherwise."
+          },
+          "customerInfo": {
+            "type": "object",
+            "$ref": "#/components/schemas/AMCSPayCustomerInfo",
+            "nullable": true,
+            "description": "The customer details associated to the refund request. Optional."
+          }
+        }
+      },
+      "AMCSPayVaultRequest": {
+        "required": [
+          "requestType",
+          "paymentType",
+          "transactionOrigin",
+          "callerIdentifier",
+          "requestId",
+          "providerType",
+          "tokenReference"
+        ],
+        "type": "object",
+        "properties": {
+          "requestType": {
+            "type": "string",
+            "enum": [
+              "VaultOrAutoPayment"
+            ],
+            "example": "VaultOrAutoPayment",
+            "nullable": false,
+            "description": "Request type for this endpoint. Always \"VaultOrAutoPayment\" — this endpoint charges a previously stored payment profile (from a prior Tokenization request via OneOff)."
+          },
+          "paymentType": {
+            "type": "string",
+            "enum": [
+              "CARD",
+              "ACH",
+              "EFT"
+            ],
+            "example": "CARD",
+            "nullable": false,
+            "description": "The payment instrument type for this request.\n\n- **CARD** — Card payment (credit/debit).\n- **ACH** — US bank account transfer (Automated Clearing House).\n- **EFT** — Canadian bank account transfer (Electronic Funds Transfer)."
+          },
+          "transactionOrigin": {
+            "type": "string",
+            "enum": [
+              "MOTO",
+              "ECOM"
+            ],
+            "example": "MOTO",
+            "nullable": false,
+            "description": "Determines whether the payment was operator-initiated or customer-initiated — this affects card scheme compliance classification.\n\n- **MOTO** — Mail Order / Telephone Order. Use when an AMCS operator keys in the payment on the customer's behalf (e.g. a phone payment). This is a Merchant-Initiated Transaction (MIT).\n- **ECOM** — E-commerce. Use when the customer enters their own payment details through a self-service channel (e.g. an online portal). This is a Customer-Initiated Transaction (CIT).\n\nUsing the wrong value can misclassify liability under card network compliance rules. Required for Stripe — the APG/EFT Canada exemption from this requirement does not apply to Stripe."
+          },
+          "callerIdentifier": {
+            "type": "string",
+            "example": "Elemos",
+            "nullable": false,
+            "description": "The identification associated to the calling application."
+          },
+          "requestId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "00000000-0000-0000-0000-000000000000",
+            "nullable": false,
+            "description": "The Caller supplied GUID associated to the Payment request."
+          },
+          "providerType": {
+            "type": "string",
+            "enum": [
+              "ACICards",
+              "ACIElectronic",
+              "Heartland",
+              "MerchantPartners",
+              "PaymentExpress",
+              "Realex",
+              "EftCanada",
+              "Stripe"
+            ],
+            "example": "ACICards",
+            "nullable": false,
+            "description": "The payment provider used to process this request.\n\n- **ACICards** — ACI Worldwide card processing.\n- **ACIElectronic** — ACI Worldwide ACH/electronic processing.\n- **Heartland** — Heartland Payment Systems.\n- **MerchantPartners** — Merchant Partners.\n- **PaymentExpress** — Payment Express (Windcave).\n- **Realex** — Realex/Global Payments.\n- **EftCanada** — EFT Canada bank transfers.\n- **Stripe** — Stripe card processing. `transactionOrigin` is required when using Stripe — the APG/EFT Canada exemption from that requirement does not apply."
           },
           "transactionAmount": {
             "type": "object",
@@ -4146,38 +4420,45 @@
             "type": "string",
             "format": "uuid",
             "example": "00000000-0000-0000-0000-000000000000",
-            "nullable": false
+            "nullable": false,
+            "description": "The AMCS generated Response GUID associated to the Payment request."
           },
           "providerReference": {
             "type": "string",
             "example": "8ac7a4a28749242d01874c7e648327b7",
-            "nullable": true
+            "nullable": true,
+            "description": "The reference number associated to the payment provider response."
           },
           "providerResponseCode": {
             "type": "string",
             "example": "Success",
-            "nullable": false
+            "nullable": false,
+            "description": "The status code associated to the payment provider response."
           },
           "providerAuthCode": {
             "type": "string",
             "example": "",
-            "nullable": true
+            "nullable": true,
+            "description": "The authorization code associated to the payment provider."
           },
           "transactionAmount": {
             "type": "object",
             "$ref": "#/components/schemas/AMCSPayAmount",
-            "nullable": false
+            "nullable": false,
+            "description": "The amount associated to the payment request."
           },
           "responseTimeStamp": {
             "type": "string",
             "format": "datetime",
             "example": "2022-07-27 18:54:18.6767965 +08:00",
-            "nullable": false
+            "nullable": false,
+            "description": "The time stamp associated to the response payload."
           },
           "notes": {
             "type": "string",
             "example": "",
-            "nullable": true
+            "nullable": true,
+            "description": "More information associated to the payment."
           },
           "transactionStatus": {
             "type": "string",
@@ -4186,7 +4467,8 @@
               "Failure"
             ],
             "example": "Success",
-            "nullable": false
+            "nullable": false,
+            "description": "The Transaction Status associated to the refund response.\n\n- **Success** — The refund was accepted by the provider.\n- **Failure** — The refund was not processed; check `notes`/`result` for details."
           },
           "result": {
             "$ref": "#/components/schemas/AMCSPayResult",
@@ -4196,7 +4478,8 @@
           "customerInfo": {
             "type": "object",
             "$ref": "#/components/schemas/AMCSPayCustomerInfo",
-            "nullable": true
+            "nullable": true,
+            "description": "The customer details associated to the refund response."
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
Update Swagger/OpenAPI spec for Stripe Card payments (Track 1) to unblock ERP integration
<img width="1913" height="1079" alt="image" src="https://github.com/user-attachments/assets/a005d255-c531-4d3b-8a5b-1c6b7fe0506e" />


Summary
-------

Updates the External API swagger spec (`payswaggerlatest.json`) for AMCS Pay's Stripe card endpoints so Trux/Tower (ERP integrators) can self-serve Track 1 card integration without further clarification from AMCS Pay. Fixes [896659](https://dev.azure.com/amcsgroup/Platform/_workitems/edit/896659).
**Highlights:**
*   Adds `Stripe` to the `providerType` enum on OneOff, Vault, Refund, and DeleteToken — it was never listed as a valid value despite being fully supported in code.
*   Adds `GET /ExternalTransaction/TokenVault` and `POST /ExternalTransaction/SetDefault` — previously undocumented entirely.
*   Documents every enum field (`transactionOrigin`, `paymentType`, `requestType`, `providerType`) with per-value, human-readable guidance instead of just the raw value list — including MOTO vs ECOM usage and card-scheme compliance implications, and stating explicitly that `transactionOrigin` is required for Stripe (the APG/EFT Canada exemption does not apply).
*   Fixes Refund's `transactionOrigin` enum, which was incorrectly restricted to `["MOTO"]` only.
*   Expands Poll's `transactionStatus` enum from 4 to the full 9 values.
*   Standardizes documentation style: retires the old markdown-table-in-path-description format for OneOff, Refund, and Poll in favor of per-property `description` fields (matching Vault/DeleteToken's existing convention), so every field's guidance lives on the field itself.
This is a documentation-only change — no corresponding API behavior changed; everything documented here already works in the live API.

Test plan
---------

*    JSON validated as well-formed (`python -m json.load`)
*    Confirmed every property across all touched schemas has a `description`
*    Confirmed no leftover markdown-table or raw-HTML-span remnants
*    QA: fire real requests against a Stripe-enabled dev/test tenant and diff responses against the documented schemas for all 7 endpoints (OneOff, Vault, TokenVault, DeleteToken, SetDefault, Poll, Refund)
*    Confirm spec renders correctly in Swagger UI/ReDoc after merge
*    Confirm published output at `amcsplatform.github.io/amcsrestapi` reflects the changes before sharing the URL with Trux/Tower